### PR TITLE
Pass className from props of CanvasDraw component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -219,6 +219,7 @@ export default class extends Component {
   render() {
     return (
       <canvas
+	      className={this.props.className}
         width={this.props.canvasWidth}
         height={this.props.canvasHeight}
         style={{


### PR DESCRIPTION
I was using the CanvasDraw component for a side project and thought it would be nice to be able to pass a className to the CanvasDraw component and it get passed and applied to the canvas component that actually get rendered. Just a small usability tweak.

P.S. - This is my first open source PR ever so if I did something wrong lmk 😊