### PR TITLE
Properly unobserve on componentWillUnmount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -99,10 +99,10 @@ export default class extends PureComponent {
     });
     this.chainLength = this.props.lazyRadius * window.devicePixelRatio;
 
-    const observeCanvas = new ResizeObserver((entries, observer) =>
+    this.canvasObserver = new ResizeObserver((entries, observer) =>
       this.handleCanvasResize(entries, observer)
     );
-    observeCanvas.observe(this.canvasContainer);
+    this.canvasObserver.observe(this.canvasContainer);
 
     this.drawImage();
     this.loop();
@@ -145,6 +145,10 @@ export default class extends PureComponent {
       this.valuesChanged = true;
     }
   }
+
+  componentWillUnmount = () => {
+    this.canvasObserver.unobserve(this.canvasContainer);
+  };
 
   drawImage = () => {
     if (!this.props.imgSrc) return;


### PR DESCRIPTION
In my scenario I unmount the CanvasDraw when `window.innerWidth < 992` which resulted in the following error:

```
index.js:445 Uncaught DOMException: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The image argument is a canvas element with a width or height of 0.
    at _default._this.saveLine (http://localhost:3000/static/js/22.chunk.js:533:25)
    at http://localhost:3000/static/js/22.chunk.js:311:17
```
Those are lines
`408: this.ctx.drawing.drawImage(this.canvas.temp, 0, 0, width, height);`
and
`241: this.saveLine({ brushColor, brushRadius });`

I figured out that `saveLine` was called from `simulateDrawingLines`, from the `loadSaveData` from the `handleCanvasResize`. Which fired at the same moment, when the component actually got unmounted. The simplest solution is to properly unobserve the `ResizeObserver`, which this PR does.