### PR TITLE
Replace codecov.io by codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
 - npm install nwb
 after_success:
 - cat ./coverage/lcov.info | ./node_modules/.bin/codecov --pipe
-GuillaumeAmat-patch-1- cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+- cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ language: node_js
 node_js:
 - 8
 before_install:
-- npm install codecov.io coveralls
+- npm install codecov coveralls
 - npm install nwb
 after_success:
-- cat ./coverage/lcov.info | ./node_modules/codecov.io/bin/codecov.io.js
-- cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+- cat ./coverage/lcov.info | ./node_modules/.bin/codecov --pipe
+GuillaumeAmat-patch-1- cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
 branches:
   only:
   - master


### PR DESCRIPTION
The first one carries some vulnerabilities and as we can see in the different repos, it is not soon to be fixed...