### PR TITLE
Add codecov and coveralls as devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "nwb": "0.21.x",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "style-loader": "^0.19.1"
+    "style-loader": "^0.19.1",
+    "codecov": "3.5.x",
+    "coveralls": "3.0.x"
   },
   "author": {
     "name": "Martin Beierling",


### PR DESCRIPTION
Your [package.json on GitHub](https://github.com/embiem/react-canvas-draw/blob/c629c6534f4f3399da901563071391eae3099606/package.json) does not include Codecov and Coveralls.

However, because your [.travis.yml](https://github.com/embiem/react-canvas-draw/blob/c629c6534f4f3399da901563071391eae3099606/.travis.yml) includes commands to install both of these packages, when Travis publishes to NPM you [have Codecov and Coveralls in the deps](https://registry.npmjs.com/react-canvas-draw).

This is silly because then pulling in react-canvas-draw into a project will pull in these packages which are really only needed for development and CI.

This PR explicitly adds Codecov and Coveralls to your devDeps so that Travis won't sneak them into your regular deps!