### PR TITLE
Fix image issues on canvas resize.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -321,6 +321,7 @@ export default class extends PureComponent {
       this.setCanvasSize(this.canvas.grid, width, height);
 
       this.drawGrid(this.ctx.grid);
+      this.drawImage();
       this.loop({ once: true });
     }
     this.loadSaveData(saveData, true);


### PR DESCRIPTION
Both the grid and the image are drawn on the same canvas (grid), on resize the grid was redrawn but the image wasn't.

This should solve "images not loading in Safari #65"