### PR TITLE
'getSaveData' feature: canvas to png and jpeg

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -180,13 +180,65 @@ export default class extends PureComponent {
     this.triggerOnChange();
   };
 
-  getSaveData = () => {
+  // https://stackoverflow.com/questions/32160098/change-html-canvas-black-background-to-white-background-when-creating-jpg-image
+  canvasToRasterImage = (canvas, type, backgroundColor) => {
+    let context = canvas.getContext("2d")
+    //cache height and width		
+    let w = canvas.width;
+    let h = canvas.height;
+    let data;		
+
+    if(backgroundColor){
+      //get the current ImageData for the canvas.
+      data = context.getImageData(0, 0, w, h);
+      
+      //store the current globalCompositeOperation
+      var compositeOperation = context.globalCompositeOperation;
+
+      //set to draw behind current content
+      context.globalCompositeOperation = "destination-over";
+
+      //set background color
+      context.fillStyle = backgroundColor;
+
+      //draw background / rect on entire canvas
+      context.fillRect(0,0,w,h);
+    }
+
+    //get the image data from the canvas
+    var imageData = canvas.toDataURL(`image/${type}`);
+
+    if(backgroundColor){
+      //clear the canvas
+      context.clearRect (0,0,w,h);
+
+      //restore it with original / cached ImageData
+      context.putImageData(data, 0,0);		
+
+      //reset the globalCompositeOperation to what it was
+      context.globalCompositeOperation = compositeOperation;
+    }
+
+    //return the Base64 encoded data url string
+    return imageData;
+  }
+
+  getSaveData = (type) => {
+
+    if (type == "png") {
+      return this.canvasToRasterImage(this.canvas.drawing, type)
+    }
+    else if(type == "jpeg"){
+      return this.canvasToRasterImage(this.canvas.drawing, type, "#fff")
+    }
+
     // Construct and return the stringified saveData object
     return JSON.stringify({
       lines: this.lines,
       width: this.props.canvasWidth,
       height: this.props.canvasHeight
     });
+
   };
 
   loadSaveData = (saveData, immediate = this.props.immediateLoading) => {


### PR DESCRIPTION
Added the "png" and "jpeg" save mode.

If 'getSaveData' is called without params, it behaves in the default way. 
If the argument is 'jpeg' or 'png', the method returns the data in the specified format.