### PR TITLE
Use z-index of parent instead of hard-coding

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,24 +19,7 @@ const canvasStyle = {
   position: "absolute"
 };
 
-const canvasTypes = [
-  {
-    name: "interface",
-    zIndex: 15
-  },
-  {
-    name: "drawing",
-    zIndex: 11
-  },
-  {
-    name: "temp",
-    zIndex: 12
-  },
-  {
-    name: "grid",
-    zIndex: 10
-  }
-];
+const canvasTypes = ["grid", "drawing", "temp", "interface"];
 
 const dimensionsPropTypes = PropTypes.oneOfType([
   PropTypes.number,
@@ -572,7 +555,7 @@ export default class extends PureComponent {
           }
         }}
       >
-        {canvasTypes.map(({ name, zIndex }) => {
+        {canvasTypes.map((name) => {
           const isInterface = name === "interface";
           return (
             <canvas
@@ -583,7 +566,7 @@ export default class extends PureComponent {
                   this.ctx[name] = canvas.getContext("2d");
                 }
               }}
-              style={{ ...canvasStyle, zIndex }}
+              style={canvasStyle}
               onMouseDown={isInterface ? this.handleDrawStart : undefined}
               onMouseMove={isInterface ? this.handleDrawMove : undefined}
               onMouseUp={isInterface ? this.handleDrawEnd : undefined}

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,16 +1,10 @@
 import expect from "expect";
-import Enzyme, { shallow } from "enzyme";
-import Adapter from "enzyme-adapter-react-16";
 import React from "react";
 import { render, unmountComponentAtNode } from "react-dom";
 
 import DrawCanvas from "src/";
 
 describe("DrawCanvas", () => {
-  before(() => {
-    Enzyme.configure({ adapter: new Adapter() });
-  });
-
   let node;
 
   beforeEach(() => {


### PR DESCRIPTION
# What is this?

This change uses the natural indexing rules of the browser by ordering canvas elements, rather than specifying a hard-coded z-index. This fixes issues relating to absolutely positioned canvases.

# Context

I'm building a fun react-app that allows the moving around of little drawings on a kind of pin-board. Without this change, overlapping elements don't correctly obey the z-index of their parents, resulting in some weird visual issues:

<img width="415" alt="Screenshot 2020-05-02 at 12 43 30" src="https://user-images.githubusercontent.com/5550263/80863219-ad4ebb80-8c72-11ea-8aaf-1ef81653a3bd.png">

But with this change, the CanvasDraw elements correctly obey their parents z-index:

<img width="472" alt="Screenshot 2020-05-02 at 12 42 02" src="https://user-images.githubusercontent.com/5550263/80863227-bb9cd780-8c72-11ea-87be-fe8377376e48.png">
