### PR TITLE
Changed from `crossOrigin` to `origin` field in the image object inside drawImage function due to a CORS error in some image urls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -168,7 +168,7 @@ export default class extends PureComponent {
     this.image = new Image();
 
     // Prevent SecurityError "Tainted canvases may not be exported." #70
-    this.image.crossOrigin = "anonymous";
+    this.image.origin = "anonymous";
 
     // Draw the image once loaded
     this.image.onload = () =>


### PR DESCRIPTION
Following issue  #70 , the ` image.crossOrigin = "anonymous" ` caused a CORS error when trying to load some images (e.g https://ychef.files.bbci.co.uk/976x549/p08d422m.jpg). 
I changed it to: ` image.origin = "anonymous" ` which solves this problem.

All tests has passed.