### PR TITLE
Allow React 17 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "resize-observer-polyfill": "^1.5.0"
   },
   "peerDependencies": {
-    "react": "16.x"
+    "react": "16.x || 17.x"
   },
   "devDependencies": {
     "all-contributors-cli": "^5.4.1",


### PR DESCRIPTION
React 17 has been around for a little bit. I'm using it in a new project and would like to use this library, but the `peerDependencies` are too restrictive and I get this error:

```bash
% npm install react-canvas-draw --save
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: project@1.0.0
npm ERR! Found: react@17.0.2
npm ERR! node_modules/react
npm ERR!   react@"^17.0.2" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"16.x" from react-canvas-draw@1.1.1
npm ERR! node_modules/react-canvas-draw
npm ERR!   react-canvas-draw@"*" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
``` 

The release notes suggest that there should be exceeding few breaking changes between React 16 and 17, so I believe this is a safe change: https://reactjs.org/blog/2020/10/20/react-v17.html