### PR TITLE
Fixed bug when the user zoom the page while drawing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -412,6 +412,10 @@ export default class CanvasDraw extends PureComponent {
   };
 
   handleDrawMove = (e) => {
+    // Edge case when the user zoom the page while drawing
+    if (!this.interactionSM) {
+      this.interactionSM = new DefaultState();
+    }
     this.interactionSM = this.interactionSM.handleDrawMove(e, this);
     this.mouseHasMoved = true;
   };


### PR DESCRIPTION
When the user zoom the browser page and then starts drawing happens that the  `this.interactionSM` object is `undefined`.